### PR TITLE
Moving cut cell clean up

### DIFF
--- a/Octree/MovingCutCell/mycentered.h
+++ b/Octree/MovingCutCell/mycentered.h
@@ -144,7 +144,6 @@ event defaults (i = 0)
     face vector alphav = alpha;
     foreach_face()
       alphav.x[] = fm.x[];
-    boundary ((scalar *) {alpha});
   }
 
   /**
@@ -187,11 +186,9 @@ double dtmax;
 
 event init (i = 0)
 {
-  boundary ((scalar *) {u});
   trash ({uf});
   foreach_face()
     uf.x[] = fm.x[]*face_value (u.x, 0);
-  boundary ((scalar *) {uf});
 
   /**
   We update fluid properties. */
@@ -240,9 +237,7 @@ The fluid properties such as specific volume (fields $\alpha$ and
 $\alpha_c$) or dynamic viscosity (face field $\mu_f$) -- at time
 $t+\Delta t/2$ -- can be defined by overloading this event. */
 
-event properties (i++,last) {
-  boundary ({alpha, mu, rho});
-}
+event properties (i++,last);
 
 /**
 ### Predicted face velocity field
@@ -282,7 +277,6 @@ void prediction()
 #endif
 	  du.x[] = (u.x[1] - u.x[-1])/(2.*Delta);
     }
-  boundary ((scalar *) {du});
 
   trash ({uf});
   foreach_face() {
@@ -303,7 +297,6 @@ void prediction()
     #endif
     uf.x[] *= fm.x[];
   }
-  boundary ((scalar *) {uf});
 
   delete ((scalar *){du});
 }
@@ -337,7 +330,6 @@ static void correction (double dt)
   foreach()
     foreach_dimension()
       u.x[] += dt*g.x[];
-  boundary ((scalar *) {u});  
 }
 
 /**
@@ -388,7 +380,6 @@ event acceleration (i++,last)
   trash ({uf});
   foreach_face()
     uf.x[] = fm.x[]*(face_value (u.x, 0) + dt*a.x[]);
-  boundary ((scalar *) {uf, a});
 }
 
 /**
@@ -408,7 +399,6 @@ void centered_gradient (scalar p, vector g)
   foreach_face()
     gf.x[] = fm.x[]*a.x[] - alpha.x[]*(p[] - p[-1])/Delta; // fixme: More stable? More consistent?
     /* gf.x[] = fm.x[]*a.x[] - alpha.x[]*face_gradient_x(p, 0); */
-  boundary_flux ({gf});
   
   /**
   We average these face values to obtain the centered, combined
@@ -418,7 +408,6 @@ void centered_gradient (scalar p, vector g)
   foreach()
     foreach_dimension()
       g.x[] = (gf.x[] + gf.x[1])/(fm.x[] + fm.x[1] + SEPS);
-  boundary ((scalar *) {g});
 }
 
 /**
@@ -454,11 +443,9 @@ fluxes need to be checked for inconsistencies. */
 event adapt (i++,last) {
 #if EMBED
   fractions_cleanup (cs, fs);
-  boundary (all); // Since boundary conditions can depend on volume and face fractions
   foreach_face()
     if (uf.x[] && !fs.x[])
       uf.x[] = 0.;
-  boundary ((scalar *) {uf});
 #endif // EMBED
   event ("properties");
 }

--- a/Octree/MovingCutCell/myembed-moving.h
+++ b/Octree/MovingCutCell/myembed-moving.h
@@ -246,62 +246,74 @@ typedef struct {
   coord au, aw; // Acceleration
 } particle;
 
-typedef struct {
+struct p_Dump {
   char * file; // File name
   particle * list; // List of particles
   FILE * fp; // File pointer
   bool unbuffered;
-} p_Dump;
+};
 
-void p_dump (p_Dump p)
+void p_dump(char *file, particle *list, bool unbuffered = 1)
 {
-  FILE * fp = p.fp;
-  char def[] = "p_dump", * file = p.file ? p.file : p.fp ? NULL : def;
+  FILE *fp = NULL;
+  struct p_Dump p = { file, list, NULL, unbuffered };
 
-  char * name = NULL;
-  if (file) {
-    name = (char *) malloc (strlen(file) + 2);
-    strcpy (name, file);
-    if (!p.unbuffered)
-      strcat (name, "~");
-    if ((fp = fopen (name, "w")) == NULL) {
-      perror (name);
-      exit (1);
+  char def[] = "p_dump";
+  char *fname = p.file ? p.file : def;
+
+  char *name = NULL;
+  if (fname) {
+    name = malloc(strlen(fname) + 2);
+    if (!name) {
+      perror("malloc");
+      exit(1);
     }
-  }
-  assert (fp);
 
-  // Get particle data (only 1 particle for now)
-  int p_n = 1;
-  particle * p_list = p.list;
-
-  // Dump particle data
-  fwrite(p_list, sizeof(*p_list), p_n, fp);
-  
-  /* free (p_list); */
-  if (file) {
-    fclose (fp);
+    strcpy(name, fname);
     if (!p.unbuffered)
-      rename (name, file);
-    free (name);
+      strcat(name, "~");
+
+    if ((fp = fopen(name, "wb")) == NULL) {
+      perror(name);
+      exit(1);
+    }
+  } else {
+    // if fname == NULL but p.fp exists, use it
+    fp = p.fp;
+  }
+
+  assert(fp);
+
+  int p_n = 1;
+  particle *p_list = p.list;
+
+  fwrite(p_list, sizeof(*p_list), p_n, fp);
+
+  if (fname) {
+    fclose(fp);
+    if (!p.unbuffered)
+      rename(name, fname);
+    free(name);
   }
 }
 
-bool p_restore (p_Dump p)
+bool p_restore (char *file, particle *list, bool unbuffered = 1)
 {
-  FILE * fp = p.fp;
-  char * file = p.file;
-  if (file && (fp = fopen (file, "r")) == NULL)
+  FILE *fp = NULL;
+  struct p_Dump p = { file, list, fp, unbuffered };
+
+  char *fname = p.file;
+  if (fname && (fp = fopen(fname, "r")) == NULL)
     return 0;
-  assert (fp);
+  assert(fp);
 
   // Read particle data (only 1 particle for now)
   int p_n = 1;
-  particle * p_list = p.list;
+  particle *p_list = p.list;
 
-  if (fread (p_list, sizeof(*p_list), (p_n), fp) < 1) {
-    fprintf (ferr, "#p_restore(): error reading particle data\n");
-    exit (1);
+  if (fread(p_list, sizeof(*p_list), p_n, fp) < 1) {
+    fprintf(stderr, "#p_restore(): error reading particle data\n");
+    exit(1);
   }
 
   foreach_dimension() {
@@ -311,13 +323,14 @@ bool p_restore (p_Dump p)
     p_au.x = p_list->au.x;
     p_aw.x = p_list->aw.x;
   }
-  
-  /* free (p_list); */
-  if (file)
-    fclose (fp);
-  
+
+  /* free(p_list); */
+  if (fname)
+    fclose(fp);
+
   return true;
 }
+
 
 /**
 ## Initialization */
@@ -353,7 +366,7 @@ event init (i = 0)
     We first restore the particle properties. */
     
     particle pp_restore;
-    bool p_restart = p_restore ((p_Dump){"p_restart", &pp_restore});
+    bool p_restart = p_restore ("p_restart", &pp_restore);
     assert (p_restart == true);
 
     /**

--- a/Octree/MovingCutCell/myembed-moving.h
+++ b/Octree/MovingCutCell/myembed-moving.h
@@ -246,14 +246,14 @@ typedef struct {
   coord au, aw; // Acceleration
 } particle;
 
-struct p_Dump {
+typedef struct {
   char * file; // File name
   particle * list; // List of particles
   FILE * fp; // File pointer
   bool unbuffered;
-};
+} p_Dump;
 
-void p_dump (struct p_Dump p)
+void p_dump (p_Dump p)
 {
   FILE * fp = p.fp;
   char def[] = "p_dump", * file = p.file ? p.file : p.fp ? NULL : def;
@@ -287,7 +287,7 @@ void p_dump (struct p_Dump p)
   }
 }
 
-bool p_restore (struct p_Dump p)
+bool p_restore (p_Dump p)
 {
   FILE * fp = p.fp;
   char * file = p.file;
@@ -353,7 +353,7 @@ event init (i = 0)
     We first restore the particle properties. */
     
     particle pp_restore;
-    bool p_restart = p_restore ("p_restart", &pp_restore);
+    bool p_restart = p_restore ((p_Dump){"p_restart", &pp_restore});
     assert (p_restart == true);
 
     /**
@@ -422,7 +422,7 @@ therefore use the position and boundary conditions at time $t^n$. */
 
 event stability (i++)
 {
-  foreach(reduction(min:dtmax)) {
+  foreach(reduction(min:dtmax), nowarning) {
     if (cs[] > 0. && cs[] < 1.) {
 
       // Barycenter and normal of the embedded fragment
@@ -531,7 +531,7 @@ event advection_term (i++)
   conditions). */
 
   for (scalar s in {u, g})
-    foreach() {
+    foreach (nowarning) {
       if (csm1[] <= 0. && cs[] > 0.) {
 
   	// Normal emerged cell

--- a/Octree/MovingCutCell/myembed.h
+++ b/Octree/MovingCutCell/myembed.h
@@ -171,10 +171,10 @@ struct Cleanup {
 };
 
 trace
-int fractions_cleanup (struct Cleanup p)
+int fractions_cleanup (scalar c, face vector s,
+           double smin = 0., double cmin = 0., bool opposite = false)
+
 {
-  scalar c = p.c;
-  face vector s = p.s;
   
   /**
   Since both surface and volume fractions are altered, iterations are
@@ -182,16 +182,30 @@ int fractions_cleanup (struct Cleanup p)
   through the topology of the domain: for examples, long, unresolved
   "filaments" may need many iterations to be fully removed. */
   
-  int changed = 1, schanged = 0;
+  int changed = 1, schanged = 0, i = 0;
   for (int i = 0; i < 100 && changed; i++) {
 
     /**
     Face fractions of empty cells must be zero. */
    
     foreach_face()
-      if (s.x[] && ((!c[] || !c[-1]) || s.x[] < p.smin))
+      if (s.x[] && ((!c[] || !c[-1]) || s.x[] < smin))
 	s.x[] = 0.;
-    boundary ((scalar *) {s});
+
+    /**
+    Face fractions of full cells must be one. However, changing the
+    face fractions accordingly is more tricky. There are two possible
+    cases:
+	
+    * either only a corner is cut, and in this case we set all
+      face fractions to 1;
+	
+    * or one face is solid, and in this case we set all the other
+    faces fractions to 1. */
+
+    foreach_face()
+      if (s.x[] > 0 && (c[-1] == 1 || c[] == 1))
+	s.x[] = 1.;
 
     changed = 0;
     foreach(reduction(+:changed))
@@ -212,7 +226,7 @@ int fractions_cleanup (struct Cleanup p)
 	  
 	  If *c* is smaller than *cmin*, we also remove the cell. */
 
-	  if ((p.opposite && s.x[] == 0. && s.x[1] == 0.) || c[] < p.cmin)
+	  if ((opposite && s.x[] == 0. && s.x[1] == 0.) || c[] < cmin)
 	    c[] = 0., changed++;
 	}
 
@@ -227,37 +241,18 @@ int fractions_cleanup (struct Cleanup p)
 
 	/**
 	We finally make sure that if the volume fraction is very close
-	to 1, it is actually 1.
+	to 1, it is actually 1. */
 
-	Changing the face fractions accordingly is more tricky. There
-	are two possible cases:
-	
-	* either only a corner is cut, and in this case we set all
-	face fractions to 1;
-	
-	* or one face is solid, and in this case we set all the other
-	faces fractions to 1. */
-
-	if (fabs (1. - c[]) < 1.e-14) {
+	if (fabs (1. - c[]) < 1.e-14)
 	  c[] = 1., changed++;
-	  int nfs = 0.;
-	  foreach_dimension()
-	    for (int i = 0; i <= 1; i++) {
-	      if (s.x[i] > 0)
-		s.x[i] = 1.;
-	      else 
-		nfs += 1;
-	    }
-	  assert (nfs <= 1);
-	}
       }
-    boundary ({c});
 
     schanged += changed;
   }
-  restriction ({c, s});
   
-  assert (!changed); // not converged yet...
+  if (changed)
+    fprintf (stderr, "#WARNING: fractions_cleanup() did not converge after "
+	     "%d iterations\n", i);
   return schanged;
 }
 
@@ -270,34 +265,41 @@ conditions related to the embedded boundaries. */
 bid embed;
 
 /**
-For ease of use, we redefine the Neumann and Dirichlet boundary macros
-so that they can be used either for standard domain boundaries or for
-embedded boundaries. The distinction between the two cases is based on
-whether the `dirichlet` parameter is passed to the boundary function
-(using the `data` parameter). Note that when using boundary conditions
-for embedded boundaries, the coordinates x,y,z no longer describe the
-center of the cell but instead the barycenter $\mathbf{b}$ of the
-discrete rigid boundary $\delta \Gamma_{\Delta}$ in the cut-cell (see
-function *embed_area_center()*). */
+For ease of use, we replace the Neumann and Dirichlet functions with
+macros so that they can be used either for standard domain boundaries
+or for embedded boundaries. The distinction between the two cases is
+based on whether the `dirichlet` parameter is passed to the boundary
+function (using the `data` parameter). */
 
-@undef neumann
-@def neumann(expr)   (data ? embed_area_center (point, &x, &y, &z),
-		      *((bool *)data) = false, (expr) :
-		      Delta*(expr) + val(_s,0,0,0))
-@
-@undef neumann_homogeneous
-@def neumann_homogeneous() (data ? *((bool *)data) = false, (0) :
-			    val(_s,0,0,0))
-@
-@undef dirichlet
-@def dirichlet(expr) (data ? embed_area_center (point, &x, &y, &z),
-		      *((bool *)data) = true, (expr) :
-		      2.*(expr) - val(_s,0,0,0))
-@
-@undef dirichlet_homogeneous
-@def dirichlet_homogeneous() (data ? *((bool *)data) = true, (0) :
-			      - val(_s,0,0,0))
-@
+macro2
+double dirichlet (double expr, Point point = point,
+		  scalar s = _s, bool * data = data)
+{
+  return data ? embed_area_center (point, &x, &y, &z),
+    *((bool *)data) = true, expr : 2.*expr - s[];
+}
+
+macro2
+double dirichlet_homogeneous (double expr, Point point = point,
+			      scalar s = _s, bool * data = data)
+{
+  return data ? *((bool *)data) = true, 0 : - s[];
+}
+
+macro2
+double neumann (double expr, Point point = point,
+		scalar s = _s, bool * data = data)
+{
+  return data ? embed_area_center (point, &x, &y, &z),
+    *((bool *)data) = false, expr : Delta*expr + s[];
+}
+
+macro2
+double neumann_homogeneous (double expr, Point point = point,
+			    scalar s = _s, bool * data = data)
+{
+  return data ? *((bool *)data) = false, 0 : s[];
+}
 
 /**
 ## Operator overloading
@@ -932,7 +934,6 @@ double neumann_scalar (Point point, scalar s, scalar cs,
   double d[2], v[2] = {nodata,nodata};
   embed_evaluate (point, s, cs, n, b, &d[0], &v[0], &d[1], &v[1]);
 
-
   /**
   This is a degenerate case, we use the gradient boundary condition
   and the cell-center value to define the value of the scalar at the
@@ -1344,10 +1345,8 @@ These two vectors are computed by the *embed_force()* function.
 trace
 void embed_force (scalar p, vector u, face vector mu, coord * Fp, coord * Fmu)
 {
-  // fixme: this could be simplified considerably if reduction worked on vectors
-  double Fp_x = 0., Fp_y = 0., Fp_z = 0., Fmu_x = 0., Fmu_y = 0., Fmu_z = 0.;
-  foreach (reduction(+:Fp_x) reduction(+:Fp_y) reduction(+:Fp_z)
-	   reduction(+:Fmu_x) reduction(+:Fmu_y) reduction(+:Fmu_z)) {
+  coord Fps = {0}, Fmus = {0};
+  foreach (reduction(+:Fps) reduction(+:Fmus), nowarning)
     if (cs[] > 0. && cs[] < 1.) {
 
       /**
@@ -1362,7 +1361,7 @@ void embed_force (scalar p, vector u, face vector mu, coord * Fp, coord * Fmu)
 
       double Fn = area*embed_interpolate (point, p, b);
       foreach_dimension()
-	Fp_x += Fn*n.x;
+	Fps.x += Fn*n.x;
           
       /**
       To compute the viscous force, we first need to retrieve the
@@ -1467,21 +1466,18 @@ void embed_force (scalar p, vector u, face vector mu, coord * Fp, coord * Fmu)
 	coord dudn = embed_gradient (point, u, b, n);
 #if dimension == 2
 	foreach_dimension()
-	  Fmu_x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y);
+	  Fmus.x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y);
 #else // dimension == 3
 	foreach_dimension()
-	  Fmu_x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y +
-			     dudn.z*n.x*n.z);
+	  Fmus.x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y +
+			      dudn.z*n.x*n.z);
 #endif // dimension
       }
     }
-  }
-  foreach_dimension() {
-    Fp->x = Fp_x;
-    Fmu->x = Fmu_x;
-  }
+  
+  *Fp = Fps; *Fmu = Fmus;
 }
 
 /**
@@ -1490,10 +1486,8 @@ embedded boundaries, using the user defined color scalar *color*. */
 
 void embed_color_force (scalar p, vector u, face vector mu, scalar color, coord * Fp, coord * Fmu)
 {
-  // fixme: this could be simplified considerably if reduction worked on vectors
-  double Fp_x = 0., Fp_y = 0., Fp_z = 0., Fmu_x = 0., Fmu_y = 0., Fmu_z = 0.;
-  foreach (reduction(+:Fp_x) reduction(+:Fp_y) reduction(+:Fp_z)
-	   reduction(+:Fmu_x) reduction(+:Fmu_y) reduction(+:Fmu_z)) {
+  coord Fps = {0}, Fmus = {0};
+  foreach (reduction(+:Fps) reduction(+:Fmus))
     if (cs[] > 0. && cs[] < 1. && color[] > 0. && color[] < 1.) {
 
       coord n, b;
@@ -1502,7 +1496,7 @@ void embed_color_force (scalar p, vector u, face vector mu, scalar color, coord 
 
       double Fn = area*embed_interpolate (point, p, b);
       foreach_dimension()
-	Fp_x += Fn*n.x;
+	Fps.x += Fn*n.x;
           
       if (constant(mu.x) != 0.) {
 	double mua = 0., fa = 0.;
@@ -1515,21 +1509,18 @@ void embed_color_force (scalar p, vector u, face vector mu, scalar color, coord 
 	coord dudn = embed_gradient (point, u, b, n);
 #if dimension == 2
 	foreach_dimension()
-	  Fmu_x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y);
+	  Fmus.x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y);
 #else // dimension == 3
 	foreach_dimension()
-	  Fmu_x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y +
-			     dudn.z*n.x*n.z);
+	  Fmus.x -= area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y +
+			      dudn.z*n.x*n.z);
 #endif // dimension
       }
     }
-  }
-  foreach_dimension() {
-    Fp->x  = Fp_x;
-    Fmu->x = Fmu_x;
-  }
+
+  *Fp = Fps; *Fmu = Fmus;  
 }
 
 /**
@@ -1561,9 +1552,8 @@ ressembles the function *embed_force()*.
 trace
 void embed_torque (scalar p, vector u, face vector mu, coord c, coord * Tp, coord * Tmu)
 {
-  double Tp_x = 0., Tp_y = 0., Tp_z = 0., Tmu_x = 0., Tmu_y = 0., Tmu_z = 0.;
-  foreach (reduction(+:Tp_x) reduction(+:Tp_y) reduction(+:Tp_z)
-	   reduction(+:Tmu_x) reduction(+:Tmu_y) reduction(+:Tmu_z))
+  coord Tps = {0}, Tmus = {0};
+  foreach (reduction(+:Tps) reduction(+:Tmus))
     if (cs[] > 0. && cs[] < 1.) {
       
       coord n, b;
@@ -1575,7 +1565,6 @@ void embed_torque (scalar p, vector u, face vector mu, coord c, coord * Tp, coor
       *embed_force()*, we also compute the relative coordinates
       $\mathbf{x} - \mathbf{x}_{\Gamma}$. */
 
-
       // The coordinate x,y,z are not permuted with foreach_dimension()
       coord r = {x,y,z};
       // In case of a periodic domain, we shift the position of the center
@@ -1591,10 +1580,11 @@ void embed_torque (scalar p, vector u, face vector mu, coord c, coord * Tp, coor
       
       double Fn = area*embed_interpolate (point, p, b);
 #if dimension == 2
-      Tp_z += Fn*(r.x*n.y - r.y*n.x);
+      Tps.x += Fn*(r.x*n.y - r.y*n.x);
+      Tps.y = Tps.x;
 #else // dimension == 3      
       foreach_dimension()
-	Tp_x += Fn*(r.y*n.z - r.z*n.y);
+	Tps.x += Fn*(r.y*n.z - r.z*n.y);
 #endif // dimension
       
       if (constant(mu.x) != 0.) {
@@ -1606,39 +1596,29 @@ void embed_torque (scalar p, vector u, face vector mu, coord c, coord * Tp, coor
 	mua /= (fa + SEPS);
 
 	coord dudn = embed_gradient (point, u, b, n);
+	coord Fmus = {0};
 #if dimension == 2
-	double Fmu_x = 0., Fmu_y = 0.;	
 	foreach_dimension()
-	  Fmu_x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y);
+	  Fmus.x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y);
 #else // dimension == 3
-	double Fmu_x = 0., Fmu_y = 0., Fmu_z = 0.;	
 	foreach_dimension()
-	  Fmu_x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y +
-			     dudn.z*n.x*n.z);
+	  Fmus.x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y +
+			      dudn.z*n.x*n.z);
 #endif // dimension
 
 #if dimension == 2
-	Tmu_z += r.x*Fmu_y - r.y*Fmu_x;
+	Tmus.x += r.x*Fmus.y - r.y*Fmus.x;
+	Tmus.y = Tmus.x;
 #else // dimension == 3
 	foreach_dimension()
-	  Tmu_x += r.y*Fmu_z - r.z*Fmu_y;
+	  Tmus.x += r.y*Fmus.z - r.z*Fmus.y;
 #endif // dimension
       }
     }
-#if dimension == 2
-  double T_p = Tp_z, T_mu = Tmu_z;
-  foreach_dimension() {
-    Tp->x = T_p;
-    Tmu->x = T_mu;
-  }
-#else // dimension == 3
-  foreach_dimension() {
-    Tp->x = Tp_x;
-    Tmu->x = Tmu_x;
-  }
-#endif
+  
+  *Tp = Tps; *Tmu = Tmus;
 }
 
 /**
@@ -1647,14 +1627,18 @@ embedded boundaries, using the user defined color scalar *color*. */
 
 void embed_color_torque (scalar p, vector u, face vector mu, scalar color, coord c, coord * Tp, coord * Tmu)
 {
-  double Tp_x = 0., Tp_y = 0., Tp_z = 0., Tmu_x = 0., Tmu_y = 0., Tmu_z = 0.;
-  foreach (reduction(+:Tp_x) reduction(+:Tp_y) reduction(+:Tp_z)
-	   reduction(+:Tmu_x) reduction(+:Tmu_y) reduction(+:Tmu_z))
+  coord Tps = {0}, Tmus = {0};
+  foreach (reduction(+:Tps) reduction(+:Tmus))
     if (cs[] > 0. && cs[] < 1. && color[] > 0. && color[] < 1.) {
       
       coord n, b;
       double area = embed_geometry (point, &b, &n);
       area *= pow (Delta, dimension - 1);
+
+      /**
+      In addition to the quantities computed in the function
+      *embed_force()*, we also compute the relative coordinates
+      $\mathbf{x} - \mathbf{x}_{\Gamma}$. */
 
       // The coordinate x,y,z are not permuted with foreach_dimension()
       coord r = {x,y,z};
@@ -1671,10 +1655,11 @@ void embed_color_torque (scalar p, vector u, face vector mu, scalar color, coord
       
       double Fn = area*embed_interpolate (point, p, b);
 #if dimension == 2
-      Tp_z += Fn*(r.x*n.y - r.y*n.x);
+      Tps.x += Fn*(r.x*n.y - r.y*n.x);
+      Tps.y = Tps.x;
 #else // dimension == 3      
       foreach_dimension()
-	Tp_x += Fn*(r.y*n.z - r.z*n.y);
+	Tps.x += Fn*(r.y*n.z - r.z*n.y);
 #endif // dimension
       
       if (constant(mu.x) != 0.) {
@@ -1686,39 +1671,29 @@ void embed_color_torque (scalar p, vector u, face vector mu, scalar color, coord
 	mua /= (fa + SEPS);
 
 	coord dudn = embed_gradient (point, u, b, n);
+	coord Fmus = {0};
 #if dimension == 2
-	double Fmu_x = 0., Fmu_y = 0.;	
 	foreach_dimension()
-	  Fmu_x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y);
+	  Fmus.x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y);
 #else // dimension == 3
-	double Fmu_x = 0., Fmu_y = 0., Fmu_z = 0.;	
 	foreach_dimension()
-	  Fmu_x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
-			     dudn.y*n.x*n.y +
-			     dudn.z*n.x*n.z);
+	  Fmus.x = -area*mua*(dudn.x*(sq (n.x) + 1.) +
+			      dudn.y*n.x*n.y +
+			      dudn.z*n.x*n.z);
 #endif // dimension
 
 #if dimension == 2
-	Tmu_z += r.x*Fmu_y - r.y*Fmu_x;
+	Tmus.x += r.x*Fmus.y - r.y*Fmus.x;
+	Tmus.y = Tmus.x;
 #else // dimension == 3
 	foreach_dimension()
-	  Tmu_x += r.y*Fmu_z - r.z*Fmu_y;
+	  Tmus.x += r.y*Fmus.z - r.z*Fmus.y;
 #endif // dimension
       }
     }
-#if dimension == 2
-  double T_p = Tp_z, T_mu = Tmu_z;
-  foreach_dimension() {
-    Tp->x = T_p;
-    Tmu->x = T_mu;
-  }
-#else // dimension == 3
-  foreach_dimension() {
-    Tp->x = Tp_x;
-    Tmu->x = Tmu_x;
-  }
-#endif
+  
+  *Tp = Tps; *Tmu = Tmus;
 }
 
 /**
@@ -1765,8 +1740,9 @@ embedded boundary. */
 static inline double bilinear_embed (Point point, scalar s)
 {
   if (!coarse(cs)) {
-    assert (coarse(s) == 0.);
-    return coarse(s); // 0
+    /* assert (coarse(s) == 0.); */
+    /* return coarse(s); // 0 */
+    return 0;
   }
   if (!coarse(cs,child.x) ||
       (!emerged && !coarse(csm1,child.x)))
@@ -1973,7 +1949,7 @@ void update_tracer (scalar f, face vector uf, face vector flux, double dt)
   The modified default *bilinear_embed* refinement/prolongation is
   sufficient for *divfc* and *divfc_corr* on trees. */
     
-  foreach() {
+  foreach (nowarning) {
     
     /**
     If the cell is empty, the divergence is zero. */
@@ -2078,7 +2054,6 @@ void update_tracer (scalar f, face vector uf, face vector flux, double dt)
       divfc_cor[] /= (Delta*cs[]);
     }
   }
-  boundary ({divfc, divfc_cor});
 
   /**
   Following [Sverdrup et al., 2019](#sverdrup2019), we compute in each
@@ -2153,7 +2128,7 @@ void update_tracer (scalar f, face vector uf, face vector flux, double dt)
   The modified default *bilinear_embed* refinement/prolongation is
   sufficient on trees for *e*. */
   
-  foreach() {
+  foreach (nowarning) {
 
     if (cs[] <= 0.)
       e[] = 0.;
@@ -2223,7 +2198,6 @@ void update_tracer (scalar f, face vector uf, face vector flux, double dt)
       e[] = dt*cs[]*(1. - kc)*((divfc[] + divfc_cor[]) - divfnc)/(scs + SEPS);
     }
   }
-  boundary ({e});
 
   /**
   In a second phase, the excess *e* in each cell is added to the
@@ -2275,7 +2249,6 @@ event metric (i = 0)
   default `refine` method calls the prolongation method for each
   component. */
 #endif
-  boundary    ({cs, csm1, fs});
   restriction ({cs, csm1, fs});
 
   // fixme: embedded boundaries cannot be combined with (another) metric yet
@@ -2289,6 +2262,14 @@ event metric (i = 0)
   at restart. */
   
   csm1.nodump = true;
+}
+
+/**
+We add the embedded boundary to the default display. */
+
+event defaults (i = 0 ) {
+  display ("draw_vof (c = 'cs', s = 'fs', filled = -1, "
+	   "fc = {0.5,0.5,0.5}, order = 2);");
 }
 
 /**
@@ -2312,8 +2293,7 @@ event metric (i = 0)
   title={A Cartesian grid embedded boundary method for the heat equation 
   and Poisson’s equation in three dimensions},
   author={Schwartz, Peter and Barad, Michael and Colella, Phillip and Ligocki, 
-  Terry},
-  journal={Journal of Computational Physics},
+  Terry}, journal={Journal of Computational Physics},
   volume={211},
   number={2},
   pages={531--550},
@@ -2345,7 +2325,7 @@ event metric (i = 0)
 }
 
 @article{miller2012,
-  title={An embedded boundary method for the Navier–Stokes equations on a time-dependent domain},
+  title={An embedded boundary method for the Navier–Stokes equationon a time-dependent domain},
   author={Miller, G. and Trebotich, D.},
   journal={Communications in Applied Mathematics and Computational Science},
   volume={7},

--- a/Octree/MovingCutCell/mypoisson.h
+++ b/Octree/MovingCutCell/mypoisson.h
@@ -22,6 +22,11 @@ $$
 where the right-hand-side is often called the *residual* of the
 approximate solution $\tilde{a}$.
 
+### Note:
+This is essentially a copy of present [poisson.h](/src/poisson.h).
+To account for non-zero dirichlet boundary condition on embedded boundaries,
+you'll find a straight plug-in Ghigo's original implementation: a modication of the divergence computation within the *project* function.
+
 ## Multigrid cycle
 
 Here we implement the multigrid cycle proper. Given an initial guess
@@ -29,6 +34,7 @@ Here we implement the multigrid cycle proper. Given an initial guess
 function *relax*, we will provide an improved guess at the end of the
 cycle. */
 
+trace
 void mg_cycle (scalar * a, scalar * res, scalar * da,
 	       void (* relax) (scalar * da, scalar * res, 
 			       int depth, void * data),
@@ -56,26 +62,26 @@ void mg_cycle (scalar * a, scalar * res, scalar * da,
 	for (scalar s in da)
 	  foreach_blockf (s)
 	    s[] = 0.;
-    
+
     /**
     On all other grids, we take as initial guess the approximate solution
     on the coarser grid bilinearly interpolated onto the current grid. */
 
-    else
+    else {
+      boundary_level (da, l - 1);
       foreach_level (l)
 	for (scalar s in da)
 	  foreach_blockf (s)
 	    s[] = bilinear (point, s);
-
-
+    }
+    
     /**
     We then apply homogeneous boundary conditions and do several
     iterations of the relaxation function to refine the initial guess. */
 
-    boundary_level (da, l);
     for (int i = 0; i < nrelax; i++) {
-      relax (da, res, l, data);
       boundary_level (da, l);
+      relax (da, res, l, data);
     }
   }
 
@@ -88,7 +94,6 @@ void mg_cycle (scalar * a, scalar * res, scalar * da,
       foreach_blockf (s)
 	s[] += ds[];
   }
-  boundary (a);
 }
 
 /**
@@ -102,7 +107,7 @@ The maximum number of iterations is controlled by *NITERMAX* and the
 tolerance by *TOLERANCE* with the default values below. */
 
 int NITERMAX = 100, NITERMIN = 1;
-double TOLERANCE = 1e-3;
+double TOLERANCE = 1e-3 [*];
 
 /**
 Information about the convergence of the solver is returned in a structure. */
@@ -119,43 +124,32 @@ typedef struct {
 The user needs to provide a function which computes the residual field
 (and returns its maximum) as well as the relaxation function. The
 user-defined pointer *data* can be used to pass arguments to these
-functions. The optional number of relaxations is *nrelax* (default is
-one) and *res* is an optional list of fields used to store the
-residuals. The minimum level of the hierarchy can be set (default is
-zero i.e. the root cell). */
+functions. The optional number of relaxations is *nrelax* and *res* is
+an optional list of fields used to store the residuals. The minimum
+level of the hierarchy can be set (default is zero i.e. the root
+cell). */
 
-struct MGSolve {
-  scalar * a, * b;
-  double (* residual) (scalar * a, scalar * b, scalar * res,
-		       void * data);
-  void (* relax) (scalar * da, scalar * res, int depth, 
-		  void * data);
-  void * data;
-  
-  int nrelax;
-  scalar * res;
-  int minlevel;
-  double tolerance;
-};
-
-/**
-Note that it is important here that the volume and face fractions
-fields *cs* and *fs* are defined on all levels of the grid. The user
-must therefore make sure that, in case of mesh adaptation or moving
-embedded boundaries, and if the fluid properties such as *mu*, *alpha*
-and *rho* do not point directly to *fs* or *cs*, the embedded
-fractions *cs* and *fs* are properly *restricted*. */
-
-mgstats mg_solve (struct MGSolve p)
+trace
+mgstats mg_solve (scalar * a, scalar * b,
+		  double (* residual) (scalar * a, scalar * b, scalar * res,
+				       void * data),
+		  void (* relax) (scalar * da, scalar * res, int depth, 
+				  void * data),
+		  void * data = NULL,
+		  int nrelax = 4,
+		  scalar * res = NULL,
+		  int minlevel = 0,
+		  double tolerance = TOLERANCE)
 {
+
   /**
   We allocate a new correction and residual field for each of the scalars
   in *a*. */
 
-  scalar * da = list_clone (p.a), * res = p.res;
+  scalar * da = list_clone (a), * pres = res;
   if (!res)
-    res = list_clone (p.b);
-  
+    res = list_clone (b);
+
   /**
   The boundary conditions for the correction fields are the
   *homogeneous* equivalent of the boundary conditions applied to
@@ -170,33 +164,31 @@ mgstats mg_solve (struct MGSolve p)
 
   mgstats s = {0};
   double sum = 0.;
+  scalar rhs = b[0];
   foreach (reduction(+:sum))
-    for (scalar s in p.b)
-      sum += s[];
+    sum += rhs[];
   s.sum = sum;
-  s.nrelax = p.nrelax > 0 ? p.nrelax : 4;
+  s.nrelax = nrelax > 0 ? nrelax : 4;
   
   /**
   Here we compute the initial residual field and its maximum. */
 
   double resb;
-  resb = s.resb = s.resa = p.residual (p.a, p.b, res, p.data);
+  resb = s.resb = s.resa = (* residual) (a, b, res, data);
 
   /**
   We then iterate until convergence or until *NITERMAX* is reached. Note
   also that we force the solver to apply at least one cycle, even if the
   initial residual is lower than *TOLERANCE*. */
-
-  if (p.tolerance == 0.)
-    p.tolerance = TOLERANCE;
+  
   for (s.i = 0;
-       s.i < NITERMAX && (s.i < NITERMIN || s.resa > p.tolerance);
+       s.i < NITERMAX && (s.i < NITERMIN || s.resa > tolerance);
        s.i++) {
-    mg_cycle (p.a, res, da, p.relax, p.data,
+    mg_cycle (a, res, da, relax, data,
 	      s.nrelax,
-	      p.minlevel,
+	      minlevel,
 	      grid->maxdepth);
-    s.resa = p.residual (p.a, p.b, res, p.data);
+    s.resa = (* residual) (a, b, res, data);
 
     /**
     We tune the number of relaxations so that the residual is reduced
@@ -205,7 +197,7 @@ mgstats mg_solve (struct MGSolve p)
     on the finest grid. */
 
 #if 1
-    if (s.resa > p.tolerance) {
+    if (s.resa > tolerance) {
       if (resb/s.resa < 1.2 && s.nrelax < 100)
 	s.nrelax++;
       else if (resb/s.resa > 10 && s.nrelax > 2)
@@ -220,23 +212,23 @@ mgstats mg_solve (struct MGSolve p)
 
     resb = s.resa;
   }
-  s.minlevel = p.minlevel;
+  s.minlevel = minlevel;
   
   /**
   If we have not satisfied the tolerance, we warn the user. */
 
-  if (s.resa > p.tolerance) {
-    scalar v = p.a[0];
-    fprintf (stderr, 
-	     "#WARNING: convergence for %s not reached after %d iterations\n"
-	     "#  res: %g sum: %g nrelax: %d\n", v.name,
-	     s.i, s.resa, s.sum, s.nrelax), fflush (stderr);
+  if (s.resa > tolerance) {
+    scalar v = a[0]; // fixme: should not be necessary
+    fprintf (ferr, 
+	     "src/poisson.h:%d: warning: convergence for %s not reached after %d iterations\n"
+	     "  res: %g sum: %g nrelax: %d tolerance: %g\n", LINENO, v.name,
+	     s.i, s.resa, s.sum, s.nrelax, tolerance), fflush (ferr);
   }
     
   /**
   We deallocate the residual and correction fields and free the lists. */
 
-  if (!p.res)
+  if (!pres)
     delete (res), free (res);
   delete (da), free (da);
 
@@ -262,11 +254,7 @@ default *TOLERANCE* of the multigrid solver, *nrelax* controls the
 initial number of relaxations (default is one), *minlevel* controls
 the minimum level of the hierarchy (default is one) and *res* is an
 optional list of fields used to store the final residual (which can be
-useful to monitor convergence).
-
-When using [embedded boundaries](embed.h) boundary fluxes on the
-boundary need to be included. They are computed by the *embed_flux*
-function. */
+useful to monitor convergence). */
 
 struct Poisson {
   scalar a, b;
@@ -292,13 +280,13 @@ static void relax (scalar * al, scalar * bl, int l, void * data)
   (const) scalar lambda = p->lambda;
 
   /**
-  We use either Jacobi (under)relaxation or we directly reuse values
-  as soon as they are updated. For Jacobi, we need to allocate space
-  for the new field *c*. Jacobi is useful mostly as it gives results
-  which are independent of the order in which the cells are
-  traversed. This is not the case for the simple traversal, which
-  means for example that results will depend on whether a tree or
-  a multigrid is used (because cells will be traversed in a different
+  We use either Jacobi (under)relaxation, Gauss-Seidel or we directly
+  reuse values as soon as they are updated. For Jacobi, we need to
+  allocate space for the new field *c*. Jacobi is useful mostly as it
+  gives results which are independent of the order in which the cells
+  are traversed. This is not the case for the simple traversal, which
+  means for example that results will depend on whether a tree or a
+  multigrid is used (because cells will be traversed in a different
   order). The same comment applies to OpenMP or MPI parallelism. In
   practice however Jacobi convergence tends to be slower than simple
   reuse. */
@@ -308,12 +296,25 @@ static void relax (scalar * al, scalar * bl, int l, void * data)
 #else
   scalar c = a;
 #endif
-  
-  /**
-  We use the face values of $\alpha$ to weight the gradients of the
-  5-points Laplacian operator. We get the relaxation function. */
 
-  foreach_level_or_leaf (l) {
+  /**
+  On GPUs, we use red/black Gauss-Seidel relaxation, which requires
+  two loops (for odd/even indices). Note also that, unlike the other
+  option, red/black relaxation should be deterministic. */
+  
+#if GAUSS_SEIDEL || _GPU
+  for (int parity = 0; parity < 2; parity++)
+    foreach_level_or_leaf (l, nowarning)
+      if (level == 0 || ((point.i + parity) % 2) != (point.j % 2))
+#else
+  foreach_level_or_leaf (l, nowarning)
+#endif
+  {
+
+    /**
+    We use the face values of $\alpha$ to weight the gradients of the
+    5-points Laplacian operator. We get the relaxation function. */
+
     double n = - sq(Delta)*b[], d = - lambda[]*sq(Delta);
     foreach_dimension() {
       n += alpha.x[1]*a[1] + alpha.x[]*a[-1];
@@ -326,7 +327,7 @@ static void relax (scalar * al, scalar * bl, int l, void * data)
       d += e*sq(Delta);
     }
     if (!d)
-      c[] = b[] = 0.;
+      c[] = 0., b[] = 0.;
     else
 #endif // EMBED
       c[] = n/d;
@@ -367,23 +368,22 @@ static double residual (scalar * al, scalar * bl, scalar * resl, void * data)
   face vector g[];
   foreach_face()
     g.x[] = alpha.x[]*face_gradient_x (a, 0);
-  boundary_flux ({g});
-  foreach (reduction(max:maxres)) {
+  foreach (reduction(max:maxres), nowarning) {
     res[] = b[] - lambda[]*a[];
     foreach_dimension()
       res[] -= (g.x[1] - g.x[])/Delta;
 #if EMBED
     if (p->embed_flux) {
       double c, e = p->embed_flux (point, a, alpha, &c);
-      res[] += c + e*a[];
+      res[] += c - e*a[];
     }
 #endif // EMBED    
     if (fabs (res[]) > maxres)
       maxres = fabs (res[]);
-  }    
+  }
 #else // !TREE
   /* "naive" discretisation (only 1st order on trees) */
-  foreach (reduction(max:maxres)) {
+  foreach (reduction(max:maxres), nowarning) {
     res[] = b[] - lambda[]*a[];
     foreach_dimension()
       res[] += (alpha.x[0]*face_gradient_x (a, 0) -
@@ -391,15 +391,13 @@ static double residual (scalar * al, scalar * bl, scalar * resl, void * data)
 #if EMBED
     if (p->embed_flux) {
       double c, e = p->embed_flux (point, a, alpha, &c);
-      /* res[] += c - e*a[]; */
-      res[] += c + e*a[];
+      res[] += c - e*a[];
     }
-#endif // EMBED    
+#endif // EMBED
     if (fabs (res[]) > maxres)
       maxres = fabs (res[]);
   }
-#endif // !TREE    
-  boundary (resl);
+#endif // !TREE
   return maxres;
 }
 
@@ -412,7 +410,15 @@ $$
 \nabla\cdot (\alpha\nabla a) + \lambda a = b
 $$ */
 
-mgstats poisson (struct Poisson p)
+trace
+mgstats poisson (scalar a, scalar b,
+		 (const) face vector alpha = {{-1}},
+		 (const) scalar lambda = {-1},
+		 double tolerance = 0.,
+		 int nrelax = 4,
+		 int minlevel = 0,
+		 scalar * res = NULL,
+		 double (* flux) (Point, scalar, vector, double *) = NULL)
 {
 
   /**
@@ -420,16 +426,16 @@ mgstats poisson (struct Poisson p)
   unity vector (resp. zero scalar) fields. Note that the user is free to
   provide $\alpha$ and $\beta$ as constant fields. */
 
-  if (!p.alpha.x.i)
-    p.alpha = unityf;
-  if (!p.lambda.i)
-    p.lambda = zeroc;
+  if (alpha.x.i < 0)
+    alpha[] = {1.,1.,1.};
+  if (lambda.i < 0)
+    lambda[] = 0.;
+
+
 
   /**
   We need $\alpha$ and $\lambda$ on all levels of the grid. */
 
-  face vector alpha = p.alpha;
-  scalar lambda = p.lambda;
   restriction ({alpha,lambda});
 
   /**
@@ -437,21 +443,23 @@ mgstats poisson (struct Poisson p)
   solver. */
 
   double defaultol = TOLERANCE;
-  if (p.tolerance)
-    TOLERANCE = p.tolerance;
+  if (tolerance)
+    TOLERANCE = tolerance;
 
-  scalar a = p.a, b = p.b;
+  struct Poisson p = {a, b, alpha, lambda, tolerance, nrelax, minlevel, res };
 #if EMBED
-  if (!p.embed_flux && a.boundary[embed] != symmetry)
+  if (!flux && a.boundary[embed] != symmetry)
     p.embed_flux = embed_flux;
+  else
+    p.embed_flux = flux;
 #endif // EMBED
-  mgstats s = mg_solve ({a}, {b}, residual, relax,
-			&p, p.nrelax, p.res, minlevel = max(1, p.minlevel));
+  mgstats s = mg_solve ({a}, {b}, residual, relax, &p,
+			nrelax, res, max(1, minlevel));
 
   /**
   We restore the default. */
 
-  if (p.tolerance)
+  if (tolerance)
     TOLERANCE = defaultol;
 
   return s;
@@ -474,22 +482,12 @@ $$
 \nabla\cdot(\alpha\nabla p) = \frac{\nabla\cdot\mathbf{u}_f}{\Delta t}
 $$ */
 
-struct Project {
-  face vector uf;
-  scalar p;
-  face vector alpha; // optional: default unityf
-  double dt;         // optional: default one
-  int nrelax;        // optional: default four
-};
-
 trace
-mgstats project (struct Project q)
+mgstats project (face vector uf, scalar p,
+		 (const) face vector alpha = unityf,
+		 double dt = 1.,
+		 int nrelax = 4)
 {
-  face vector uf = q.uf;
-  scalar p = q.p;
-  (const) face vector alpha = q.alpha.x.i ? q.alpha : unityf;
-  double dt = q.dt ? q.dt : 1.;
-  int nrelax = q.nrelax ? q.nrelax : 4;
   
   /**
   We allocate a local scalar field and compute the divergence of
@@ -515,15 +513,11 @@ mgstats project (struct Project q)
   *div* here. */
     
   scalar div[];
-
-  /* div.refine = div.prolongation = refine_embed_linear; */
-  /* div.restriction = restriction_embed_linear; */
-
-  foreach() {
+  foreach(nowarning) { //added nowarning so to avoid...warnings. TO BE TESTED
     div[] = 0.;
     foreach_dimension()
       div[] += uf.x[1] - uf.x[];
-#if EMBED
+#if EMBED // THIS IS THE ONLY REAL DIFFERENCE FROM PRESENT poisson.h FP 2025324_13h16
     if (cs[] > 0. && cs[] < 1.) {
       coord b, n;
       double area = embed_geometry (point, &b, &n);
@@ -555,7 +549,6 @@ mgstats project (struct Project q)
 
   foreach_face()
     uf.x[] -= dt*alpha.x[]*face_gradient_x (p, 0);
-  boundary ((scalar *) {uf});
 
   return mgp;
 }

--- a/Octree/MovingCutCell/myviscosity-embed.h
+++ b/Octree/MovingCutCell/myviscosity-embed.h
@@ -1,27 +1,55 @@
-#include "mypoisson.h"
+/**
+# Viscous solver with embedded boundaries
+
+We consider the Stokes equations
+$$
+\rho \mathbf{u}_t = \rho \mathbf{g} +
+\nabla \cdot [\mu ( \nabla \mathbf{u} + \nabla^T \mathbf{u})]
+$$
+with $\mathbf{g}$ the acceleration and $T$ the transpose.
+
+In the case of incompressible flow and uniform viscosity, the viscous term
+can be further simplified. Since
+$$
+\nabla \cdot (\mu  \nabla \mathbf{u}) =
+(\nabla \mu) \cdot \nabla \mathbf{u} + \mu \nabla (\nabla \cdot  \mathbf{u}) = 0
+$$
+the viscous term reduces to
+$$
+\nabla \cdot [\mu ( \nabla \mathbf{u} + \nabla^T \mathbf{u})] =
+\nabla \cdot (\mu \nabla^T \mathbf{u}) = \nabla^2 (\mu \mathbf{u})
+$$
+and the equations for each velocity component are decoupled. For each
+component $v_i$, the following discrete implicit equation is solved
+using the multigrid solver
+$$
+\frac{\Delta t} \nabla (\mu \nabla v_i^{n+1}) - (\rho + \lambda_i) v_i^{n+1}
++ \underbrace{(\rho v_i^{n} + g_i\, Delta t)}_{r_i} = 0
+$$
+$\lambda_i$ is a possible extra term due to the metric. */
+
+/**
+### Note
+This is a copy of [viscosity-embed](/src/viscosity-embed.h), where the only element that has been changed is the call to the mypoisson.h solver instead of poisson.h
+This so to account non-zero fluid velocity on embedded boundary.
+*/
+
+#include "mypoisson.h" // instead of the call to poisson.h
 
 struct Viscosity {
-  vector u;
   face vector mu;
   scalar rho;
   double dt;
-  int nrelax;
-  scalar * res;
   double (* embed_flux) (Point, scalar, vector, double *);
 };
 
 #if AXI
-// fixme: RHO here not correct
-# define lambda ((coord){1., 1. + dt/RHO*(mu.x[] + mu.x[1] + \
-					  mu.y[] + mu.y[0,1])/2./sq(y)})
+# define lambda ((coord){0, dt*(mu.x[] + mu.x[1]			\
+				+ mu.y[] + mu.y[0,1])*sq(cs[])		\
+	/(fm.x[] + fm.x[1] + fm.y[] + fm.y[0,1] + SEPS)/(cm[] + SEPS)})
+
 #else // not AXI
-# if dimension == 1
-#   define lambda ((coord){1.})
-# elif dimension == 2
-#   define lambda ((coord){1.,1.})
-# elif dimension == 3
-#   define lambda ((coord){1.,1.,1.})
-#endif
+# define lambda ((coord){0.,0.,0.})
 #endif
 
 // Note how the relaxation function uses "naive" gradients i.e. not
@@ -36,7 +64,7 @@ static void relax_diffusion (scalar * a, scalar * b, int l, void * data)
   vector u = vector(a[0]), r = vector(b[0]);
 
   double (* embed_flux) (Point, scalar, vector, double *) = p->embed_flux;
-  foreach_level_or_leaf (l) {
+  foreach_level_or_leaf (l, nowarning) {
     double avgmu = 0.;
     foreach_dimension()
       avgmu += mu.x[] + mu.x[1];
@@ -49,7 +77,7 @@ static void relax_diffusion (scalar * a, scalar * b, int l, void * data)
       foreach_dimension()
 	a += mu.x[1]*s[1] + mu.x[]*s[-1];
       u.x[] = (dt*a + (r.x[] - dt*c)*sq(Delta))/
-	(sq(Delta)*(rho[]*lambda.x + dt*d) + avgmu);
+	(sq(Delta)*(rho[] + lambda.x + dt*d) + avgmu);
     }
   }
   
@@ -82,12 +110,11 @@ static double residual_diffusion (scalar * a, scalar * b, scalar * resl,
     face vector g[];
     foreach_face()
       g.x[] = mu.x[]*face_gradient_x (s, 0);
-    boundary_flux ({g});
-    foreach (reduction(max:maxres)) {
+    foreach (reduction(max:maxres), nowarning) {
       double a = 0.;
       foreach_dimension()
 	a += g.x[] - g.x[1];
-      res.x[] = r.x[] - rho[]*lambda.x*u.x[] - dt*a/Delta;
+      res.x[] = r.x[] - (rho[] + lambda.x)*u.x[] - dt*a/Delta;
       if (embed_flux) {
 	double c, d = embed_flux (point, u.x, mu, &c);
 	res.x[] -= dt*(c + d*u.x[]);
@@ -96,16 +123,15 @@ static double residual_diffusion (scalar * a, scalar * b, scalar * resl,
 	maxres = fabs (res.x[]);
     }
   }
-  boundary (resl);
 #else
   /* "naive" discretisation (only 1st order on trees) */
-  foreach (reduction(max:maxres))
+  foreach (reduction(max:maxres), nowarning)
     foreach_dimension() {
       scalar s = u.x;
       double a = 0.;
       foreach_dimension()
 	a += mu.x[0]*face_gradient_x (s, 0) - mu.x[1]*face_gradient_x (s, 1);
-      res.x[] = r.x[] - rho[]*lambda.x*u.x[] - dt*a/Delta;
+      res.x[] = r.x[] - (rho[] + lambda.x)*u.x[] - dt*a/Delta;
       if (embed_flux) {
 	double c, d = embed_flux (point, u.x, mu, &c);
 	res.x[] -= dt*(c + d*u.x[]);
@@ -122,21 +148,20 @@ static double residual_diffusion (scalar * a, scalar * b, scalar * resl,
 double TOLERANCE_MU = 0.; // default to TOLERANCE
 
 trace
-mgstats viscosity (struct Viscosity p)
+mgstats viscosity (vector u, face vector mu, scalar rho, double dt,
+		   int nrelax = 4, scalar * res = NULL)
 {
-  vector u = p.u, r[];
-  scalar rho = p.rho;
+  vector r[];
   foreach()
     foreach_dimension()
       r.x[] = rho[]*u.x[];
 
-  face vector mu = p.mu;
   restriction ({mu, rho});
-
+  struct Viscosity p = { mu, rho, dt };
   p.embed_flux = u.x.boundary[embed] != antisymmetry ? embed_flux : NULL;
   return mg_solve ((scalar *){u}, (scalar *){r},
-		   residual_diffusion, relax_diffusion, &p, p.nrelax, p.res,
+		   residual_diffusion, relax_diffusion, &p, nrelax, res,
 		   minlevel = 1, // fixme: because of root level
                                   // BGHOSTS = 2 bug on trees
-		   tolerance = TOLERANCE_MU);
+		   tolerance = TOLERANCE_MU ? TOLERANCE_MU : TOLERANCE);
 }


### PR DESCRIPTION
This PR merges changes from Popinet and Picella for:
- mycentered.h
- myembed-moving.h
- myembed.h
- mypoisson.h
- myviscosity-embed.h

I updated myembed-moving.h to fix qcc warnings by passing structure members individually, following Popinet and Picella's code samples. All header files compile successfully with latest qcc.
Please review.